### PR TITLE
feat: Store Display Config (Fixes #46)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,6 @@ model CheckedInspection {
 
 model Display {
   uuid  String @unique
-  field String
+  field String?
   name  String
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,7 +61,7 @@ model CheckedInspection {
 }
 
 model Display {
-  uuid  String @unique
-  field String?
-  name  String
+  uuid    String  @unique
+  fieldId String?
+  name    String
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,3 +59,9 @@ model CheckedInspection {
 
   @@unique([teamNumber, criteriaId])
 }
+
+model Display {
+  uuid  String @unique
+  field String
+  name  String
+}

--- a/src/features/devices/displays/displays.controller.ts
+++ b/src/features/devices/displays/displays.controller.ts
@@ -1,48 +1,49 @@
-import { Body, Controller, Param, Post } from "@nestjs/common";
-import { DisplaysService } from "./displays.service";
+import { Body, Controller, Param, Post } from '@nestjs/common'
+import { DisplaysService } from './displays.service'
 
 interface DisplayParams {
-  uuid: string;
+  uuid: string
 }
 
-@Controller("displays")
+@Controller('displays')
 export class DisplaysController {
-  constructor(private readonly displaysService: DisplaysService) {}
+  constructor (private readonly displaysService: DisplaysService) {}
 
-  @Post(":uuid/register")
-  async registerDisplay(@Param() params: DisplayParams): Promise<void> {
-    await this.displaysService.registerDisplay(params.uuid);
+  @Post(':uuid/register')
+  async registerDisplay (@Param() params: DisplayParams): Promise<void> {
+    await this.displaysService.registerDisplay(params.uuid)
   }
 
-  @Post(":uuid/hasFieldControl")
-  async adviseHasFieldControl(
+  @Post(':uuid/hasFieldControl')
+  async adviseHasFieldControl (
     @Param() params: DisplayParams,
-    @Body() body: { hasFieldControl: boolean }
+      @Body() body: { hasFieldControl: boolean }
   ): Promise<void> {
     await this.displaysService.adviseHasFieldControl(
       params.uuid,
       body.hasFieldControl
-    );
+    )
   }
 
-  @Post(":uuid/name")
-  async setDisplayName(
+  @Post(':uuid/name')
+  async setDisplayName (
     @Param() params: DisplayParams,
-    @Body() body: { displayName: string }
+      @Body() body: { displayName: string }
   ): Promise<void> {
     await this.displaysService.setDisplayName(
       params.uuid,
       body.displayName
-    );
+    )
   }
-  @Post(":uuid/assign")
-  async assignField(
+
+  @Post(':uuid/assign')
+  async assignField (
     @Param() params: DisplayParams,
-    @Body() body: { field: string }
+      @Body() body: { field: string }
   ): Promise<void> {
     await this.displaysService.assignField(
       params.uuid,
       body.field
-    );
+    )
   }
 }

--- a/src/features/devices/displays/displays.controller.ts
+++ b/src/features/devices/displays/displays.controller.ts
@@ -1,21 +1,48 @@
-import { Body, Controller, Param, Post } from '@nestjs/common'
-import { DisplaysService } from './displays.service'
+import { Body, Controller, Param, Post } from "@nestjs/common";
+import { DisplaysService } from "./displays.service";
 
 interface DisplayParams {
-  uuid: string
+  uuid: string;
 }
 
-@Controller('displays')
+@Controller("displays")
 export class DisplaysController {
-  constructor (private readonly displaysService: DisplaysService) {}
+  constructor(private readonly displaysService: DisplaysService) {}
 
-  @Post(':uuid/register')
-  async registerDisplay (@Param() params: DisplayParams): Promise<void> {
-    await this.displaysService.registerDisplay(params.uuid)
+  @Post(":uuid/register")
+  async registerDisplay(@Param() params: DisplayParams): Promise<void> {
+    await this.displaysService.registerDisplay(params.uuid);
   }
 
-  @Post(':uuid/hasFieldControl')
-  async adviseHasFieldControl (@Param() params: DisplayParams, @Body() body: { hasFieldControl: boolean }): Promise<void> {
-    await this.displaysService.adviseHasFieldControl(params.uuid, body.hasFieldControl)
+  @Post(":uuid/hasFieldControl")
+  async adviseHasFieldControl(
+    @Param() params: DisplayParams,
+    @Body() body: { hasFieldControl: boolean }
+  ): Promise<void> {
+    await this.displaysService.adviseHasFieldControl(
+      params.uuid,
+      body.hasFieldControl
+    );
+  }
+
+  @Post(":uuid/name")
+  async setDisplayName(
+    @Param() params: DisplayParams,
+    @Body() body: { displayName: string }
+  ): Promise<void> {
+    await this.displaysService.setDisplayName(
+      params.uuid,
+      body.displayName
+    );
+  }
+  @Post(":uuid/assign")
+  async assignField(
+    @Param() params: DisplayParams,
+    @Body() body: { field: string }
+  ): Promise<void> {
+    await this.displaysService.assignField(
+      params.uuid,
+      body.field
+    );
   }
 }

--- a/src/features/devices/displays/displays.controller.ts
+++ b/src/features/devices/displays/displays.controller.ts
@@ -37,13 +37,13 @@ export class DisplaysController {
   }
 
   @Post(':uuid/assign')
-  async assignField (
+  async assignFieldId (
     @Param() params: DisplayParams,
-      @Body() body: { field: string }
+      @Body() body: { fieldId: string }
   ): Promise<void> {
-    await this.displaysService.assignField(
+    await this.displaysService.assignFieldId(
       params.uuid,
-      body.field
+      body.fieldId
     )
   }
 }

--- a/src/features/devices/displays/displays.interface.ts
+++ b/src/features/devices/displays/displays.interface.ts
@@ -7,9 +7,7 @@ export class DisplayConfig {
   })
     uuid: string
 
-  // @question should I specify it defaults to "unnamed" in description?
-  // @question idk what the display name will be
-  @ApiProperty({ description: "The display's name", example: 'placeholder' })
+  @ApiProperty({ description: "The display's name", example: 'Field Box A' })
     name: string
 
   @ApiProperty({

--- a/src/features/devices/displays/displays.interface.ts
+++ b/src/features/devices/displays/displays.interface.ts
@@ -12,10 +12,9 @@ export class DisplayConfig {
   @ApiProperty({ description: "The display's name", example: 'placeholder' })
     name: string
 
-  // @question idk what the field name will be
   @ApiProperty({
-    description: "The display's assigned field",
-    example: 'Field 1'
+    description: "The id of the display's assigned field",
+    example: '1'
   })
-    field: string | null
+    fieldId: string | null
 }

--- a/src/features/devices/displays/displays.interface.ts
+++ b/src/features/devices/displays/displays.interface.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class DisplayConfig {
+  @ApiProperty({
+    description: "The display's uuid",
+    example: '704a4ccd-48b8-4171-a4a7-3a2402cf0546'
+  })
+    uuid: string
+
+  // @question should I specify it defaults to "unnamed" in description?
+  // @question idk what the display name will be
+  @ApiProperty({ description: "The display's name", example: 'placeholder' })
+    name: string
+
+  // @question idk what the field name will be
+  @ApiProperty({
+    description: "The display's assigned field",
+    example: 'Field 1'
+  })
+    field: string | null
+}

--- a/src/features/devices/displays/displays.module.ts
+++ b/src/features/devices/displays/displays.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common'
 import { DisplaysController } from './displays.controller'
 import { DisplaysService } from './displays.service'
-import { DispplaysPublisher } from './displays.publisher'
+import { DisplaysPublisher } from './displays.publisher'
 import { PublishService } from 'src/utils/publish/publish.service'
 
 @Module({
   controllers: [DisplaysController],
-  providers: [DisplaysService, DispplaysPublisher, PublishService]
+  providers: [DisplaysService, DisplaysPublisher, PublishService]
 })
 export class DisplaysModule {}

--- a/src/features/devices/displays/displays.module.ts
+++ b/src/features/devices/displays/displays.module.ts
@@ -3,9 +3,13 @@ import { DisplaysController } from './displays.controller'
 import { DisplaysService } from './displays.service'
 import { DisplaysPublisher } from './displays.publisher'
 import { PublishService } from 'src/utils/publish/publish.service'
+import { PrismaService } from 'src/utils/prisma/prisma.service'
+import { DisplaysDatabase } from './displays.repo'
+import { InMemoryDBService } from '@nestjs-addons/in-memory-db'
 
 @Module({
   controllers: [DisplaysController],
-  providers: [DisplaysService, DisplaysPublisher, PublishService]
+  // @question not sure that this is correct (no experience with nestJS). I assume order doesn't matter 
+  providers: [DisplaysService, DisplaysPublisher, PublishService, PrismaService, DisplaysDatabase, InMemoryDBService]
 })
 export class DisplaysModule {}

--- a/src/features/devices/displays/displays.module.ts
+++ b/src/features/devices/displays/displays.module.ts
@@ -5,11 +5,11 @@ import { DisplaysPublisher } from './displays.publisher'
 import { PublishService } from 'src/utils/publish/publish.service'
 import { PrismaService } from 'src/utils/prisma/prisma.service'
 import { DisplaysDatabase } from './displays.repo'
-import { InMemoryDBService } from '@nestjs-addons/in-memory-db'
 
+// @question should something be exported (at the moment the database is only written to)
+// Currently, data is exposed when a field is assigned, at which point, the field data is published to 'displays/:uuid'
 @Module({
   controllers: [DisplaysController],
-  // @question not sure that this is correct (no experience with nestJS). I assume order doesn't matter 
-  providers: [DisplaysService, DisplaysPublisher, PublishService, PrismaService, DisplaysDatabase, InMemoryDBService]
+  providers: [DisplaysService, DisplaysPublisher, PublishService, PrismaService, DisplaysDatabase]
 })
 export class DisplaysModule {}

--- a/src/features/devices/displays/displays.publisher.ts
+++ b/src/features/devices/displays/displays.publisher.ts
@@ -1,6 +1,7 @@
 import { Payload, Publisher } from '@alecmmiller/nestjs-client-generator'
 import { Injectable } from '@nestjs/common'
 import { PublishService } from 'src/utils/publish/publish.service'
+import { DisplayConfig } from './displays.interface'
 
 const DISPLAYS_TOPIC = 'displays'
 
@@ -12,8 +13,8 @@ function makeDisplayTopic (uuid: string): string {
 export class DisplaysPublisher {
   constructor (private readonly publisher: PublishService) {}
   @Publisher(`${DISPLAYS_TOPIC}/:uuid`)
-  async publishDisplay (uuid: string, @Payload({}) fieldId: string): Promise<void> {
+  async publishDisplay (uuid: string, @Payload({}) display: DisplayConfig): Promise<void> {
     const topic = makeDisplayTopic(uuid)
-    await this.publisher.broadcast(topic, fieldId)
+    await this.publisher.broadcast(topic, display)
   }
 }

--- a/src/features/devices/displays/displays.publisher.ts
+++ b/src/features/devices/displays/displays.publisher.ts
@@ -11,7 +11,7 @@ function makeDisplayTopic (uuid: string): string {
 @Injectable()
 export class DisplaysPublisher {
   constructor (private readonly publisher: PublishService) {}
-
+  // @question would `${DISPLAYS_TOPIC}/:uuid` be better here?
   @Publisher('displays/:uuid')
   async publishDisplay (uuid: string, @Payload({}) fieldId: string): Promise<void> {
     const topic = makeDisplayTopic(uuid)

--- a/src/features/devices/displays/displays.publisher.ts
+++ b/src/features/devices/displays/displays.publisher.ts
@@ -9,7 +9,7 @@ function makeDisplayTopic (uuid: string): string {
 }
 
 @Injectable()
-export class DispplaysPublisher {
+export class DisplaysPublisher {
   constructor (private readonly publisher: PublishService) {}
 
   @Publisher('displays/:uuid')

--- a/src/features/devices/displays/displays.publisher.ts
+++ b/src/features/devices/displays/displays.publisher.ts
@@ -13,7 +13,7 @@ export class DisplaysPublisher {
   constructor (private readonly publisher: PublishService) {}
 
   @Publisher('displays/:uuid')
-  async publishDisplay (uuid: string, @Payload({}) fieldId: number): Promise<void> {
+  async publishDisplay (uuid: string, @Payload({}) fieldId: string): Promise<void> {
     const topic = makeDisplayTopic(uuid)
     await this.publisher.broadcast(topic, fieldId)
   }

--- a/src/features/devices/displays/displays.publisher.ts
+++ b/src/features/devices/displays/displays.publisher.ts
@@ -11,8 +11,7 @@ function makeDisplayTopic (uuid: string): string {
 @Injectable()
 export class DisplaysPublisher {
   constructor (private readonly publisher: PublishService) {}
-  // @question would `${DISPLAYS_TOPIC}/:uuid` be better here?
-  @Publisher('displays/:uuid')
+  @Publisher(`${DISPLAYS_TOPIC}/:uuid`)
   async publishDisplay (uuid: string, @Payload({}) fieldId: string): Promise<void> {
     const topic = makeDisplayTopic(uuid)
     await this.publisher.broadcast(topic, fieldId)

--- a/src/features/devices/displays/displays.repo.ts
+++ b/src/features/devices/displays/displays.repo.ts
@@ -1,0 +1,55 @@
+import {
+  InMemoryDBEntity,
+  InMemoryDBService,
+} from "@nestjs-addons/in-memory-db";
+import { Injectable } from "@nestjs/common";
+import { PrismaService } from "../../../utils/prisma/prisma.service";
+
+export interface DisplayDetails extends InMemoryDBEntity {
+  uuid: string;
+  name: string;
+  field: string;
+}
+
+@Injectable()
+export class DisplaysDatabase {
+  constructor(
+    private readonly prisma: PrismaService,
+    // @question in repo.service.ts, this is used, is it necessary here, and if so how should it be implemented?
+    private readonly cache: InMemoryDBService<DisplayDetails>
+  ) {}
+  async setDisplayName(uuid: string, name: string): Promise<void> {
+    this.prisma.display.upsert({
+      create: {
+        uuid,
+        name,
+        // @question I'm not sure what to do here because I don't fully understand how this will be consumed, so I will be using this placeholder
+        field: "null",
+      },
+      update: { name },
+      where: { uuid },
+    });
+  }
+  async setField(uuid: string, field: string): Promise<void> {
+    this.prisma.display.upsert({
+      create: {
+        uuid,
+        // @question same here
+        name: "null",
+        field,
+      },
+      update: { field },
+      where: { uuid },
+    });
+  }
+  // @question is no specified return type fine here? (weird return type) 
+  async getDetails(uuid: string) /*: Promise<DisplayDetails | null> */ {
+    return await this.prisma.display.findUnique({ where: { uuid } });
+  }
+  async getField(uuid: string): Promise<string | undefined> {
+    return (await this.getDetails(uuid))?.field;
+  }
+  async getName(uuid: string): Promise<string | undefined> {
+    return (await this.getDetails(uuid))?.name;
+  }
+}

--- a/src/features/devices/displays/displays.repo.ts
+++ b/src/features/devices/displays/displays.repo.ts
@@ -24,7 +24,8 @@ export class DisplaysDatabase {
     })
   }
 
-  async registerDisplay (uuid: string): Promise<void> {
+  /** @throws Will throw if an entry with {@link uuid} already exists */
+  async createDisplay (uuid: string): Promise<void> {
     await this.prisma.display.create({
       data: { uuid, name: 'unnamed' }
     })
@@ -32,6 +33,10 @@ export class DisplaysDatabase {
 
   async getDisplay (uuid: string): Promise<DisplayConfig | null> {
     return await this.prisma.display.findUnique({ where: { uuid } })
+  }
+
+  async getAllDisplays (): Promise<DisplayConfig[]> {
+    return await this.prisma.display.findMany()
   }
 
   async getFieldId (uuid: string): Promise<string | undefined | null> {

--- a/src/features/devices/displays/displays.repo.ts
+++ b/src/features/devices/displays/displays.repo.ts
@@ -8,19 +8,18 @@ export class DisplaysDatabase {
     private readonly prisma: PrismaService
   ) {}
 
+  /** @throws {RecordNotFound} Will throw if display with {@link uuid} is not found */
   async setDisplayName (uuid: string, name: string): Promise<void> {
-    // @question I believe this should reject if it does not find a display with uuid, should the error be handled here or handled elsewhere?
-    // should this potential to throw an error be stated in a comment of this function? (eg. /** @throws Will throw an error if display with uuid is not found */)
     await this.prisma.display.update({
       data: { name },
       where: { uuid }
     })
   }
 
-  async setField (uuid: string, field: string): Promise<void> {
-    // @question same here
+  /** @throws {RecordNotFound} Will throw if display with {@link uuid} is not found */
+  async setFieldId (uuid: string, fieldId: string): Promise<void> {
     await this.prisma.display.update({
-      data: { field },
+      data: { fieldId },
       where: { uuid }
     })
   }
@@ -35,8 +34,8 @@ export class DisplaysDatabase {
     return await this.prisma.display.findUnique({ where: { uuid } })
   }
 
-  async getField (uuid: string): Promise<string | undefined | null> {
-    return (await this.getDisplay(uuid))?.field
+  async getFieldId (uuid: string): Promise<string | undefined | null> {
+    return (await this.getDisplay(uuid))?.fieldId
   }
 
   async getName (uuid: string): Promise<string | undefined> {

--- a/src/features/devices/displays/displays.repo.ts
+++ b/src/features/devices/displays/displays.repo.ts
@@ -1,55 +1,45 @@
-import {
-  InMemoryDBEntity,
-  InMemoryDBService,
-} from "@nestjs-addons/in-memory-db";
-import { Injectable } from "@nestjs/common";
-import { PrismaService } from "../../../utils/prisma/prisma.service";
-
-export interface DisplayDetails extends InMemoryDBEntity {
-  uuid: string;
-  name: string;
-  field: string;
-}
+import { Injectable } from '@nestjs/common'
+import { PrismaService } from '../../../utils/prisma/prisma.service'
+import { DisplayConfig } from './displays.interface'
 
 @Injectable()
 export class DisplaysDatabase {
-  constructor(
-    private readonly prisma: PrismaService,
-    // @question in repo.service.ts, this is used, is it necessary here, and if so how should it be implemented?
-    private readonly cache: InMemoryDBService<DisplayDetails>
+  constructor (
+    private readonly prisma: PrismaService
   ) {}
-  async setDisplayName(uuid: string, name: string): Promise<void> {
-    this.prisma.display.upsert({
-      create: {
-        uuid,
-        name,
-        // @question I'm not sure what to do here because I don't fully understand how this will be consumed, so I will be using this placeholder
-        field: "null",
-      },
-      update: { name },
-      where: { uuid },
-    });
+
+  async setDisplayName (uuid: string, name: string): Promise<void> {
+    // @question I believe this should reject if it does not find a display with uuid, should the error be handled here or handled elsewhere?
+    // should this potential to throw an error be stated in a comment of this function? (eg. /** @throws Will throw an error if display with uuid is not found */)
+    await this.prisma.display.update({
+      data: { name },
+      where: { uuid }
+    })
   }
-  async setField(uuid: string, field: string): Promise<void> {
-    this.prisma.display.upsert({
-      create: {
-        uuid,
-        // @question same here
-        name: "null",
-        field,
-      },
-      update: { field },
-      where: { uuid },
-    });
+
+  async setField (uuid: string, field: string): Promise<void> {
+    // @question same here
+    await this.prisma.display.update({
+      data: { field },
+      where: { uuid }
+    })
   }
-  // @question is no specified return type fine here? (weird return type) 
-  async getDetails(uuid: string) /*: Promise<DisplayDetails | null> */ {
-    return await this.prisma.display.findUnique({ where: { uuid } });
+
+  async registerDisplay (uuid: string): Promise<void> {
+    await this.prisma.display.create({
+      data: { uuid, name: 'unnamed' }
+    })
   }
-  async getField(uuid: string): Promise<string | undefined> {
-    return (await this.getDetails(uuid))?.field;
+
+  async getDisplay (uuid: string): Promise<DisplayConfig | null> {
+    return await this.prisma.display.findUnique({ where: { uuid } })
   }
-  async getName(uuid: string): Promise<string | undefined> {
-    return (await this.getDetails(uuid))?.name;
+
+  async getField (uuid: string): Promise<string | undefined | null> {
+    return (await this.getDisplay(uuid))?.field
+  }
+
+  async getName (uuid: string): Promise<string | undefined> {
+    return (await this.getDisplay(uuid))?.name
   }
 }

--- a/src/features/devices/displays/displays.service.ts
+++ b/src/features/devices/displays/displays.service.ts
@@ -1,42 +1,43 @@
-import { Injectable, Logger } from "@nestjs/common";
-import { DisplaysPublisher } from "./displays.publisher";
-import { DisplaysDatabase } from "./displays.repo";
+import { Injectable, Logger } from '@nestjs/common'
+import { DisplaysPublisher } from './displays.publisher'
+import { DisplaysDatabase } from './displays.repo'
 
 @Injectable()
 export class DisplaysService {
-  private readonly logger = new Logger(DisplaysService.name);
+  private readonly logger = new Logger(DisplaysService.name)
 
-  constructor(
+  constructor (
     private readonly publisher: DisplaysPublisher,
     private readonly database: DisplaysDatabase
   ) {}
 
-  async registerDisplay(uuid: string): Promise<void> {
+  async registerDisplay (uuid: string): Promise<void> {
     this.logger.log(
       `Received registration request from display with UUID ${uuid}`
-    );
+    )
   }
 
-  async adviseHasFieldControl(
+  async adviseHasFieldControl (
     uuid: string,
     hasFieldControl: boolean
   ): Promise<void> {
     this.logger.log(
       `Display with UUID ${uuid} has field control: ${String(hasFieldControl)}`
-    );
+    )
   }
 
-  async setDisplayName(uuid: string, displayName: string) {
+  async setDisplayName (uuid: string, displayName: string): Promise<void> {
     this.logger.log(
       `Display with UUID ${uuid}'s name has been set to: ${displayName}`
-    );
-    this.database.setDisplayName(uuid, displayName);
+    )
+    await this.database.setDisplayName(uuid, displayName)
   }
-  async assignField(uuid: string, fieldId: string) {
+
+  async assignField (uuid: string, fieldId: string): Promise<void> {
     this.logger.log(
       `Display with UUID ${uuid} has been assigned to field: ${fieldId}`
-    );
-    this.database.setDisplayName(uuid, fieldId);
-    await this.publisher.publishDisplay(uuid, fieldId);
+    )
+    await this.database.setDisplayName(uuid, fieldId)
+    await this.publisher.publishDisplay(uuid, fieldId)
   }
 }

--- a/src/features/devices/displays/displays.service.ts
+++ b/src/features/devices/displays/displays.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common'
+import { BadRequestException, Injectable, Logger } from '@nestjs/common'
 import { DisplaysPublisher } from './displays.publisher'
 import { DisplaysDatabase } from './displays.repo'
 
@@ -30,14 +30,28 @@ export class DisplaysService {
     this.logger.log(
       `Display with UUID ${uuid}'s name has been set to: ${displayName}`
     )
-    await this.database.setDisplayName(uuid, displayName)
+    try {
+      await this.database.setDisplayName(uuid, displayName)
+    } catch {
+      this.logger.warn(
+      `Display with UUID ${uuid}'s name failed to be set to: ${displayName}\nIs there a display with UUID ${uuid}?`
+      )
+      throw new BadRequestException()
+    }
   }
 
-  async assignField (uuid: string, fieldId: string): Promise<void> {
+  async assignFieldId (uuid: string, fieldId: string): Promise<void> {
     this.logger.log(
-      `Display with UUID ${uuid} has been assigned to field: ${fieldId}`
+      `Display with UUID ${uuid} has been assigned to fieldId: ${fieldId}`
     )
-    await this.database.setDisplayName(uuid, fieldId)
+    try {
+      await this.database.setFieldId(uuid, fieldId)
+    } catch {
+      this.logger.warn(
+        `Display with UUID ${uuid} failed to be assigned to fieldId: ${fieldId}\nIs there a display with UUID ${uuid}?`
+      )
+      throw new BadRequestException()
+    }
     await this.publisher.publishDisplay(uuid, fieldId)
   }
 }

--- a/src/features/devices/displays/displays.service.ts
+++ b/src/features/devices/displays/displays.service.ts
@@ -20,7 +20,7 @@ export class DisplaysService {
     const display = await this.database.getDisplay(uuid)
     if (display === null) {
       this.logger.error(
-        `Cannot broadcast DisplayConfig with UUID ${uuid} because DisplayConfig could not be found`
+        `Cannot broadcast DisplayConfig with UUID "${uuid}" because DisplayConfig could not be found`
       )
       throw new InternalServerErrorException()
     }
@@ -29,7 +29,7 @@ export class DisplaysService {
 
   async registerDisplay (uuid: string): Promise<void> {
     this.logger.log(
-      `Received registration request from display with UUID ${uuid}`
+      `Received registration request from display with UUID "${uuid}"`
     )
     if (await this.database.getDisplay(uuid) === null) { await this.database.createDisplay(uuid) }
     await this.broadcastConfig(uuid)
@@ -40,19 +40,19 @@ export class DisplaysService {
     hasFieldControl: boolean
   ): Promise<void> {
     this.logger.log(
-      `Display with UUID ${uuid} has field control: ${String(hasFieldControl)}`
+      `Display with UUID "${uuid}" has field control: ${String(hasFieldControl)}`
     )
   }
 
   async setDisplayName (uuid: string, displayName: string): Promise<void> {
     this.logger.log(
-      `Display with UUID ${uuid}'s name has been set to: ${displayName}`
+      `Display with UUID "${uuid}" 's name has been set to: "${displayName}"`
     )
     try {
       await this.database.setDisplayName(uuid, displayName)
     } catch {
       this.logger.warn(
-      `Display with UUID ${uuid}'s name failed to be set to: ${displayName}\n\tIs there a display with UUID ${uuid}?`
+      `Display with UUID "${uuid}" 's name failed to be set to: "${displayName}"\n\tIs there a display with UUID "${uuid}"?`
       )
       throw new BadRequestException()
     }
@@ -61,13 +61,13 @@ export class DisplaysService {
 
   async assignFieldId (uuid: string, fieldId: string): Promise<void> {
     this.logger.log(
-      `Display with UUID ${uuid} has been assigned to fieldId: ${fieldId}`
+      `Display with UUID "${uuid}" has been assigned to fieldId: "${fieldId}"`
     )
     try {
       await this.database.setFieldId(uuid, fieldId)
     } catch {
       this.logger.warn(
-        `Display with UUID ${uuid} failed to be assigned to fieldId: ${fieldId}\n\tIs there a display with UUID ${uuid}?`
+        `Display with UUID "${uuid}" failed to be assigned to fieldId: "${fieldId}"\n\tIs there a display with UUID "${uuid}"?`
       )
       throw new BadRequestException()
     }

--- a/src/features/devices/displays/displays.service.ts
+++ b/src/features/devices/displays/displays.service.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common'
-import { DispplaysPublisher } from './displays.publisher'
+import { DisplaysPublisher } from './displays.publisher'
 
 @Injectable()
 export class DisplaysService {
   private readonly logger = new Logger(DisplaysService.name)
 
-  constructor (private readonly publisher: DispplaysPublisher) {}
+  constructor (private readonly publisher: DisplaysPublisher) {}
 
   async registerDisplay (uuid: string): Promise<void> {
     this.logger.log(`Received registration request from display with UUID ${uuid}`)

--- a/src/features/devices/displays/displays.service.ts
+++ b/src/features/devices/displays/displays.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, Logger } from '@nestjs/common'
+import { BadRequestException, Injectable, Logger, InternalServerErrorException } from '@nestjs/common'
 import { DisplaysPublisher } from './displays.publisher'
 import { DisplaysDatabase } from './displays.repo'
 
@@ -11,10 +11,28 @@ export class DisplaysService {
     private readonly database: DisplaysDatabase
   ) {}
 
+  async onApplicationBootstrap (): Promise<void> {
+    const displays = await this.database.getAllDisplays()
+    await Promise.all(displays.map(async (display) => await this.broadcastConfig(display.uuid)))
+  }
+
+  private async broadcastConfig (uuid: string): Promise<void> {
+    const display = await this.database.getDisplay(uuid)
+    if (display === null) {
+      this.logger.error(
+        `Cannot broadcast DisplayConfig with UUID ${uuid} because DisplayConfig could not be found`
+      )
+      throw new InternalServerErrorException()
+    }
+    await this.publisher.publishDisplay(uuid, display)
+  }
+
   async registerDisplay (uuid: string): Promise<void> {
     this.logger.log(
       `Received registration request from display with UUID ${uuid}`
     )
+    if (await this.database.getDisplay(uuid) === null) { await this.database.createDisplay(uuid) }
+    await this.broadcastConfig(uuid)
   }
 
   async adviseHasFieldControl (
@@ -34,10 +52,11 @@ export class DisplaysService {
       await this.database.setDisplayName(uuid, displayName)
     } catch {
       this.logger.warn(
-      `Display with UUID ${uuid}'s name failed to be set to: ${displayName}\nIs there a display with UUID ${uuid}?`
+      `Display with UUID ${uuid}'s name failed to be set to: ${displayName}\n\tIs there a display with UUID ${uuid}?`
       )
       throw new BadRequestException()
     }
+    await this.broadcastConfig(uuid)
   }
 
   async assignFieldId (uuid: string, fieldId: string): Promise<void> {
@@ -48,10 +67,10 @@ export class DisplaysService {
       await this.database.setFieldId(uuid, fieldId)
     } catch {
       this.logger.warn(
-        `Display with UUID ${uuid} failed to be assigned to fieldId: ${fieldId}\nIs there a display with UUID ${uuid}?`
+        `Display with UUID ${uuid} failed to be assigned to fieldId: ${fieldId}\n\tIs there a display with UUID ${uuid}?`
       )
       throw new BadRequestException()
     }
-    await this.publisher.publishDisplay(uuid, fieldId)
+    await this.broadcastConfig(uuid)
   }
 }

--- a/src/features/devices/displays/displays.service.ts
+++ b/src/features/devices/displays/displays.service.ts
@@ -46,13 +46,13 @@ export class DisplaysService {
 
   async setDisplayName (uuid: string, displayName: string): Promise<void> {
     this.logger.log(
-      `Display with UUID "${uuid}" 's name has been set to: "${displayName}"`
+      `Setting name of display ${uuid} to: "${displayName}"`
     )
     try {
       await this.database.setDisplayName(uuid, displayName)
     } catch {
       this.logger.warn(
-      `Display with UUID "${uuid}" 's name failed to be set to: "${displayName}"\n\tIs there a display with UUID "${uuid}"?`
+        `Display with UUID "${uuid}" was not found`
       )
       throw new BadRequestException()
     }
@@ -61,13 +61,13 @@ export class DisplaysService {
 
   async assignFieldId (uuid: string, fieldId: string): Promise<void> {
     this.logger.log(
-      `Display with UUID "${uuid}" has been assigned to fieldId: "${fieldId}"`
+      `Assigning display ${uuid} to field: "${fieldId}"`
     )
     try {
       await this.database.setFieldId(uuid, fieldId)
     } catch {
       this.logger.warn(
-        `Display with UUID "${uuid}" failed to be assigned to fieldId: "${fieldId}"\n\tIs there a display with UUID "${uuid}"?`
+        `Display with UUID "${uuid}" was not found?`
       )
       throw new BadRequestException()
     }

--- a/src/features/devices/displays/displays.service.ts
+++ b/src/features/devices/displays/displays.service.ts
@@ -1,18 +1,42 @@
-import { Injectable, Logger } from '@nestjs/common'
-import { DisplaysPublisher } from './displays.publisher'
+import { Injectable, Logger } from "@nestjs/common";
+import { DisplaysPublisher } from "./displays.publisher";
+import { DisplaysDatabase } from "./displays.repo";
 
 @Injectable()
 export class DisplaysService {
-  private readonly logger = new Logger(DisplaysService.name)
+  private readonly logger = new Logger(DisplaysService.name);
 
-  constructor (private readonly publisher: DisplaysPublisher) {}
+  constructor(
+    private readonly publisher: DisplaysPublisher,
+    private readonly database: DisplaysDatabase
+  ) {}
 
-  async registerDisplay (uuid: string): Promise<void> {
-    this.logger.log(`Received registration request from display with UUID ${uuid}`)
-    await this.publisher.publishDisplay(uuid, 1)
+  async registerDisplay(uuid: string): Promise<void> {
+    this.logger.log(
+      `Received registration request from display with UUID ${uuid}`
+    );
   }
 
-  async adviseHasFieldControl (uuid: string, hasFieldControl: boolean): Promise<void> {
-    this.logger.log(`Display with UUID ${uuid} has field control: ${String(hasFieldControl)}`)
+  async adviseHasFieldControl(
+    uuid: string,
+    hasFieldControl: boolean
+  ): Promise<void> {
+    this.logger.log(
+      `Display with UUID ${uuid} has field control: ${String(hasFieldControl)}`
+    );
+  }
+
+  async setDisplayName(uuid: string, displayName: string) {
+    this.logger.log(
+      `Display with UUID ${uuid}'s name has been set to: ${displayName}`
+    );
+    this.database.setDisplayName(uuid, displayName);
+  }
+  async assignField(uuid: string, fieldId: string) {
+    this.logger.log(
+      `Display with UUID ${uuid} has been assigned to field: ${fieldId}`
+    );
+    this.database.setDisplayName(uuid, fieldId);
+    await this.publisher.publishDisplay(uuid, fieldId);
   }
 }


### PR DESCRIPTION
- Adds routes:
  - displays/:uuid/assign - Assign a field to a display
  - displays/:uuid/name - Set name of a display
- Adds database model Display
- Adds publisher topic
  - displays/:uuid - broadcasts DisplayConfig when Display is modified or upon application bootstrap